### PR TITLE
Camera not working properly when user grants permission to app to use camera

### DIFF
--- a/app/src/main/java/com/example/readyourresults/Camera/CamActivity.java
+++ b/app/src/main/java/com/example/readyourresults/Camera/CamActivity.java
@@ -38,6 +38,7 @@ import java.io.File;
 public class CamActivity extends AppCompatActivity implements LifecycleOwner {
     private final int REQUEST_CODE_PERMISSIONS = 10;
     private final String[] REQUIRED_PERMISSIONS = new String[1];
+    private String TAG = "CamActivity";
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -74,6 +75,8 @@ public class CamActivity extends AppCompatActivity implements LifecycleOwner {
     private void startCamera() {
         // TODO: Implement CameraX operations
         // Create configuration object for the viewfinder use case
+
+        Log.d(TAG, "startCamera() called.");
 
         PreviewConfig previewConfig = new PreviewConfig.Builder()
                 .setTargetAspectRatio(new Rational(1, 1))
@@ -149,6 +152,7 @@ public class CamActivity extends AppCompatActivity implements LifecycleOwner {
                                     String message,
                                     Throwable cause) {
                                 // insert your code here.
+                                Log.e(TAG, "Error occurred in startCamera()");
 
                             }
                         });
@@ -222,7 +226,9 @@ public class CamActivity extends AppCompatActivity implements LifecycleOwner {
             int requestCode, String[] permissions, int[] grantResults) {
         if (requestCode == REQUEST_CODE_PERMISSIONS) {
             if (allPermissionsGranted()) {
+                viewFinder = findViewById(R.id.view_finder);
                 viewFinder.post(new StartCameraRunnable());
+                overlayView = View.inflate(getApplicationContext(), R.layout.overlay_view, (ViewGroup) viewFinder.getParent());
             } else {
                 Toast.makeText(this,
                         "Permissions not granted by the user.",

--- a/app/src/main/java/com/example/readyourresults/WelcomeActivity.java
+++ b/app/src/main/java/com/example/readyourresults/WelcomeActivity.java
@@ -24,6 +24,6 @@ public class WelcomeActivity extends Activity {
                 overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                 finish();
             }
-        },3000);
+        },0);
     }
 }


### PR DESCRIPTION
**Issue:**
Camera was not working properly when user grants permission to app to use camera. The app would show two fragments (the HomeFragment and SelectFragment) at the same time instead of going directly to the camera view.

**Fixes:**
When camera permission is requested from user and the user clicks allow, the camera preview displays correctly. When the user pressed back, the app goes back to the select device menu (though we may opt to change it to go back to the home screen. Tested normal picture taking function and everything works as expected.