### PR TITLE
Fixing Test Outcome on the Results screen

### DIFF
--- a/app/src/main/java/com/example/readyourresults/AnalysisModel.java
+++ b/app/src/main/java/com/example/readyourresults/AnalysisModel.java
@@ -27,6 +27,7 @@ import java.util.List;
 public class AnalysisModel {
     Bitmap bitmapImage;
     private String label;
+    private float maxConfidence;
     private HashMap<String, Float> labelConfidences = new HashMap<>();
 
     private ResultsInterpreted resultsInterpreted;
@@ -82,12 +83,13 @@ public class AnalysisModel {
                                 if (confidence > max) {
                                     max = confidence;
                                     maxLabel = lab.getText();
+                                    setLabel(maxLabel);
+                                    setMaxConfidence(max);
                                 }
                             }
-                            Log.d("AnalysisModel: ", labelConfidences.toString());
-                            setLabel(maxLabel);
+                            Log.d("AnalysisModel: ", labelConfidences.toString() + "max label:" + maxLabel);
 
-                            resultsInterpreted.resultsInterpreted(labelConfidences);
+                            resultsInterpreted.resultsInterpreted(labelConfidences, maxLabel, maxConfidence);
                         }
                     })
                     .addOnFailureListener(new OnFailureListener() {
@@ -109,5 +111,9 @@ public class AnalysisModel {
     }
     private void setLabel(String l) {
         this.label = l;
+    }
+
+    private void setMaxConfidence(float maxConfidence) {
+        this.maxConfidence = maxConfidence;
     }
 }

--- a/app/src/main/java/com/example/readyourresults/BufferActivity.java
+++ b/app/src/main/java/com/example/readyourresults/BufferActivity.java
@@ -24,6 +24,8 @@ public class BufferActivity extends AppCompatActivity {
         final String testType = getIntent().getStringExtra("Test Type");
         final String imagePath = getIntent().getStringExtra("Image Path");
         String msg = getIntent().getStringExtra("IMAGE_SUCCESSFULLY_CAPTURED");
+        final String maxLabel = getIntent().getStringExtra("MAXLABEL");
+        final Float maxConfidence = getIntent().getFloatExtra("MAXCONFIDENCE", 0f);
         Snackbar.make(findViewById(R.id.activity_buffer_layout), msg, Snackbar.LENGTH_SHORT).show();
 
         TextView analyzingResult = (TextView) findViewById(R.id.summary);
@@ -42,6 +44,8 @@ public class BufferActivity extends AppCompatActivity {
                 intent.putExtra("Image Path", imagePath);
                 intent.putExtra("RESULTS_AND_CONFIDENCES",
                         getIntent().getStringExtra("RESULTS_AND_CONFIDENCES"));
+                intent.putExtra("MAXLABEL", maxLabel);
+                intent.putExtra("MAXCONFIDENCE", maxConfidence);
                 startActivity(intent);
             }
         });

--- a/app/src/main/java/com/example/readyourresults/Camera/CamActivity.java
+++ b/app/src/main/java/com/example/readyourresults/Camera/CamActivity.java
@@ -67,6 +67,41 @@ public class CamActivity extends AppCompatActivity implements LifecycleOwner, Re
         finish();
     }
 
+    public void resultsInterpreted(HashMap<String, Float> labelConfidences, String maxLabel) {
+        String formattedLabels;
+        if (labelConfidences.isEmpty()) {
+            formattedLabels = "Could not determine a result based on the provided image. An inconclusive result is commonly caused by poor image quality factors such as bad lighting or blurriness.";
+        } else {
+            formattedLabels = formatLabels(labelConfidences);
+        }
+        intent.putExtra("hash", labelConfidences);
+        intent.putExtra("RESULTS_AND_CONFIDENCES", formattedLabels);
+        intent.putExtra("MAXLABEL", maxLabel);
+        progressBar.setVisibility(View.GONE);
+        analyzingText.setVisibility(View.GONE);
+        startActivity(intent);
+        Log.d("CamActivity Callback: ", "Label Confidences: " + labelConfidences);
+        finish();
+    }
+
+    public void resultsInterpreted(HashMap<String, Float> labelConfidences, String maxLabel, float maxConfidence) {
+        String formattedLabels;
+        if (labelConfidences.isEmpty()) {
+            formattedLabels = "Could not determine a result based on the provided image. An inconclusive result is commonly caused by poor image quality factors such as bad lighting or blurriness.";
+        } else {
+            formattedLabels = formatLabels(labelConfidences);
+        }
+        intent.putExtra("hash", labelConfidences);
+        intent.putExtra("RESULTS_AND_CONFIDENCES", formattedLabels);
+        intent.putExtra("MAXLABEL", maxLabel);
+        intent.putExtra("MAXCONFIDENCE", maxConfidence);
+        progressBar.setVisibility(View.GONE);
+        analyzingText.setVisibility(View.GONE);
+        startActivity(intent);
+        Log.d("CamActivity Callback: ", "Label Confidences: " + labelConfidences);
+        finish();
+    }
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/example/readyourresults/Camera/ResultsInterpreted.java
+++ b/app/src/main/java/com/example/readyourresults/Camera/ResultsInterpreted.java
@@ -4,4 +4,6 @@ import java.util.HashMap;
 
 public interface ResultsInterpreted {
     public void resultsInterpreted(HashMap<String, Float> labelConfidences);
+    public void resultsInterpreted(HashMap<String, Float> labelConfidences, String maxLabel);
+    public void resultsInterpreted(HashMap<String, Float> labelConfidences, String maxLabel, float maxConfidence);
 }

--- a/app/src/main/java/com/example/readyourresults/TestResult/NewResultFragment.java
+++ b/app/src/main/java/com/example/readyourresults/TestResult/NewResultFragment.java
@@ -38,6 +38,7 @@ public class NewResultFragment extends Fragment {
     Bitmap bitmapImage;
     TextView testType;
     TextView testOutcome;
+    TextView highestConfidenceLabel;
     TextView testDate;
     Button saveButton;
     Button closeButton;
@@ -61,6 +62,7 @@ public class NewResultFragment extends Fragment {
         //testType = getView().findViewById(R.id.testType);
         testOutcome = getView().findViewById(R.id.test_result_outcome_text);
         //testDate = getView().findViewById(R.id.testDate);
+        highestConfidenceLabel = getView().findViewById(R.id.test_result_outcome_text);
         saveButton = getView().findViewById(R.id.save_result_btn);
         closeButton = getView().findViewById(R.id.close_result_btn);
 
@@ -78,6 +80,26 @@ public class NewResultFragment extends Fragment {
         }
 
         final String testTypeText = getActivity().getIntent().getStringExtra("Test Type");
+
+        final String mostLikelyTestOutcome = getActivity().getIntent().getStringExtra("MAXLABEL");
+        final float highestConfidence = getActivity().getIntent().getFloatExtra("MAXCONFIDENCE", 0);
+        Log.d("newResultFrag", "most likely outcome: " + mostLikelyTestOutcome + "; highestConfidence: " + highestConfidence);
+
+        String additionalConfidencesInfo = "";
+        if (highestConfidence >= .8) {
+            if (mostLikelyTestOutcome.equals("reactive")) {
+                highestConfidenceLabel.setText("Positive");
+            } else if (mostLikelyTestOutcome.equals("non-reactive") || mostLikelyTestOutcome.equals("nonreactive")) {
+                highestConfidenceLabel.setText("Negative");
+            } else if (mostLikelyTestOutcome.equals("inconclusive")) {
+                highestConfidenceLabel.setText("Inconclusive");
+            } else if (mostLikelyTestOutcome.equals("invalid")) {
+                highestConfidenceLabel.setText("Invalid");
+            }
+        }else {
+            highestConfidenceLabel.setText("Inconclusive");
+            additionalConfidencesInfo = "\nThe confidence levels are not high enough to generate a strong conclusion.";
+        }
 
         dateFormat = new SimpleDateFormat("yyyy/MM/dd");
         date = new Date();
@@ -107,8 +129,7 @@ public class NewResultFragment extends Fragment {
         //show confidences
         String labels = getArguments().getString("CONFIDENCES");
         TextView confidences = getActivity().findViewById(R.id.confidences_text);
-
-        confidences.setText(labels);
+        confidences.setText(labels + additionalConfidencesInfo);
     }
 
     @Override

--- a/app/src/main/res/layout/fragment_new_result.xml
+++ b/app/src/main/res/layout/fragment_new_result.xml
@@ -57,8 +57,7 @@
                 android:layout_width="346dp"
                 android:layout_height="wrap_content"
                 android:gravity="center"
-                android:text="error"
-                android:textStyle="bold"
+                android:text=""
                 tools:layout_editor_absoluteX="32dp"
                 tools:layout_editor_absoluteY="511dp"/>
 
@@ -80,13 +79,20 @@
                     android:text="Analysis details of the results could not be found."/>
 
                 <TextView
+                    android:id="@+id/counseling_message_title_text"
+                    android:layout_width="346dp"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp"
+                    android:gravity="center_horizontal"
+                    android:text="What to Do Next:"
+                    android:textStyle="bold"/>
+                <TextView
                     android:id="@+id/counseling_message_text"
                     android:layout_width="346dp"
                     android:layout_height="wrap_content"
                     android:padding="8dp"
                     android:gravity="center_horizontal"
-                    android:text="Counseling message goes here"
-                    android:textStyle="bold"/>
+                    android:text="Please see your doctor if you have concerns about your status."/>
             </LinearLayout>
 
     </LinearLayout>


### PR DESCRIPTION
Fixing "Test Outcome" on the Results screen to output an answer instead of hard-coded "Inconclusive".